### PR TITLE
feat: add OpenRouter provider and model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ ANTHROPIC_API_KEY=your_anthropic_api_key  # Get from https://console.anthropic.c
 OPENAI_API_KEY=your_openai_api_key  # Get from https://platform.openai.com (GPT-5)
 GEMINI_API_KEY=your_gemini_api_key  # Get from https://aistudio.google.com/app/apikey
 GROQ_API_KEY=your_groq_api_key  # Get from https://console.groq.com (Fast inference - Kimi K2 recommended)
+
+# OpenRouter (unified API for many models)
+OPENROUTER_API_KEY=your_openrouter_api_key  # Get from https://openrouter.ai
 ```
 
 3. **Run**

--- a/app/api/analyze-edit-intent/route.ts
+++ b/app/api/analyze-edit-intent/route.ts
@@ -21,6 +21,11 @@ const openai = createOpenAI({
   baseURL: process.env.OPENAI_BASE_URL,
 });
 
+const openrouter = createOpenAI({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  baseURL: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1',
+});
+
 // Schema for the AI's search plan - not file selection!
 const searchPlanSchema = z.object({
   editType: z.enum([
@@ -103,6 +108,8 @@ export async function POST(request: NextRequest) {
       } else {
         aiModel = openai(model.replace('openai/', ''));
       }
+    } else if (model.startsWith('openrouter/')) {
+      aiModel = openrouter(model.replace('openrouter/', ''));
     } else if (model.startsWith('google/')) {
       aiModel = createGoogleGenerativeAI(model.replace('google/', ''));
     } else {

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -28,6 +28,11 @@ const openai = createOpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
 
+const openrouter = createOpenAI({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  baseURL: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1',
+});
+
 // Helper function to analyze user preferences from conversation history
 function analyzeUserPreferences(messages: ConversationMessage[]): {
   commonPatterns: string[];
@@ -1154,11 +1159,26 @@ CRITICAL: When files are provided in the context:
         // Determine which provider to use based on model
         const isAnthropic = model.startsWith('anthropic/');
         const isGoogle = model.startsWith('google/');
+        const isOpenRouter = model.startsWith('openrouter/');
         const isOpenAI = model.startsWith('openai/gpt-5');
-        const modelProvider = isAnthropic ? anthropic : (isOpenAI ? openai : (isGoogle ? googleGenerativeAI : groq));
-        const actualModel = isAnthropic ? model.replace('anthropic/', '') : 
-                           (model === 'openai/gpt-5') ? 'gpt-5' :
-                           (isGoogle ? model.replace('google/', '') : model);
+        const modelProvider = isAnthropic
+          ? anthropic
+          : isOpenAI
+          ? openai
+          : isGoogle
+          ? googleGenerativeAI
+          : isOpenRouter
+          ? openrouter
+          : groq;
+        const actualModel = isAnthropic
+          ? model.replace('anthropic/', '')
+          : model === 'openai/gpt-5'
+          ? 'gpt-5'
+          : isGoogle
+          ? model.replace('google/', '')
+          : isOpenRouter
+          ? model.replace('openrouter/', '')
+          : model;
 
         // Make streaming API call with appropriate provider
         const streamOptions: any = {

--- a/config/app.config.ts
+++ b/config/app.config.ts
@@ -35,7 +35,10 @@ export const appConfig = {
       'openai/gpt-5',
       'moonshotai/kimi-k2-instruct',
       'anthropic/claude-sonnet-4-20250514',
-      'google/gemini-2.5-pro'
+      'google/gemini-2.5-pro',
+      'openrouter/openai/gpt-4o-mini',
+      'openrouter/anthropic/claude-3.7-sonnet',
+      'openrouter/google/gemini-2.0-flash-exp'
     ],
     
     // Model display names
@@ -43,7 +46,10 @@ export const appConfig = {
       'openai/gpt-5': 'GPT-5',
       'moonshotai/kimi-k2-instruct': 'Kimi K2 Instruct',
       'anthropic/claude-sonnet-4-20250514': 'Sonnet 4',
-      'google/gemini-2.5-pro': 'Gemini 2.5 Pro'
+      'google/gemini-2.5-pro': 'Gemini 2.5 Pro',
+      'openrouter/openai/gpt-4o-mini': 'OpenRouter: GPT-4o mini',
+      'openrouter/anthropic/claude-3.7-sonnet': 'OpenRouter: Sonnet 3.7',
+      'openrouter/google/gemini-2.0-flash-exp': 'OpenRouter: Gemini 2.0 Flash Exp'
     },
     
     // Temperature settings for non-reasoning models

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.1",
+        "@ai-sdk/google": "^2.0.4",
         "@ai-sdk/groq": "^2.0.0",
         "@ai-sdk/openai": "^2.0.4",
         "@anthropic-ai/sdk": "^0.57.0",
@@ -90,6 +91,40 @@
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
         "@ai-sdk/provider-utils": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.6.tgz",
+      "integrity": "sha512-8acuseWJI+RRH99JDWM/n7IJRuuGNa4YzLXB/leqE/ZByHyIiVWGADjJi/vfnJnmdM5fQnezJ6SRTF6feI5rSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.3.tgz",
+      "integrity": "sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.3",
+        "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"


### PR DESCRIPTION
1. Added OpenRouter client with baseURL https://openrouter.ai/api/v1
2. Routed models prefixed with openrouter/ to OpenRouter and stripped the prefix before sending the model (e.g., openrouter/openai/gpt-4o → openai/gpt-4o)
3. Supported OpenRouter in app/api/generate-ai-code-stream/route.ts and app/api/analyze-edit-intent/route.ts
4. Extended config/app.config.ts with couple of OpenRouter models and display names