### PR TITLE
Docs: Update setup instructions to use pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,37 @@ Chat with AI to build React apps instantly. An example app made by the [Firecraw
 
 ## Setup
 
-1. **Clone & Install**
+First, ensure you have [pnpm](https://pnpm.io/installation) installed. If you don't have it, you can install it with npm:
 ```bash
-git clone https://github.com/mendableai/open-lovable.git
-cd open-lovable
-npm install
+npm install -g pnpm
 ```
+
+Then, follow these steps:
+
+1. **Clone & Install**
+    ```bash
+    git clone https://github.com/mendableai/open-lovable.git
+    cd open-lovable
+    pnpm install
+    ```
 
 2. **Add `.env.local`**
-```env
-# Required
-E2B_API_KEY=your_e2b_api_key  # Get from https://e2b.dev (Sandboxes)
-FIRECRAWL_API_KEY=your_firecrawl_api_key  # Get from https://firecrawl.dev (Web scraping)
+    ```env
+    # Required
+    E2B_API_KEY=your_e2b_api_key  # Get from https://e2b.dev (Sandboxes)
+    FIRECRAWL_API_KEY=your_firecrawl_api_key  # Get from https://firecrawl.dev (Web scraping)
 
-# Optional (need at least one AI provider)
-ANTHROPIC_API_KEY=your_anthropic_api_key  # Get from https://console.anthropic.com
-OPENAI_API_KEY=your_openai_api_key  # Get from https://platform.openai.com (GPT-5)
-GEMINI_API_KEY=your_gemini_api_key  # Get from https://aistudio.google.com/app/apikey
-GROQ_API_KEY=your_groq_api_key  # Get from https://console.groq.com (Fast inference - Kimi K2 recommended)
-```
+    # Optional (need at least one AI provider)
+    ANTHROPIC_API_KEY=your_anthropic_api_key  # Get from https://console.anthropic.com
+    OPENAI_API_KEY=your_openai_api_key  # Get from https://platform.openai.com (GPT-5)
+    GEMINI_API_KEY=your_gemini_api_key  # Get from https://aistudio.google.com/app/apikey
+    GROQ_API_KEY=your_groq_api_key  # Get from https://console.groq.com (Fast inference - Kimi K2 recommended)
+    ```
 
 3. **Run**
-```bash
-npm run dev
-```
+    ```bash
+    pnpm run dev
+    ```
 
 Open [http://localhost:3000](http://localhost:3000)  
 


### PR DESCRIPTION
This pull request updates the `README.md` to recommend `pnpm` for dependency installation and for running the development server.

**Reasoning:**

The project contains a `pnpm-lock.yaml` file, which indicates that `pnpm` is the intended package manager. The previous instructions recommended `npm`, which could lead to several issues for new contributors:

*   **Dependency Mismatches:** `npm` and `pnpm` can resolve dependencies differently, potentially leading to a `node_modules` state that is inconsistent with the lock file. This can cause subtle bugs or break the application, like the `lightningcss` error that was encountered.
*   **Incorrect Lock File:** If a user runs `npm install`, a `package-lock.json` file might be created, leading to confusion about which lock file is the source of truth.
*   **Installation Errors:** As seen, using the wrong package manager can lead to native addon installation failures if the resolution differs from what the lock file expects.

By aligning the documentation with the project's setup, we can provide a smoother onboarding experience for new developers and prevent common setup-related issues.

This change also includes a note on how to install `pnpm` for users who might not have it installed.