### PR TITLE
Add Gemini BaseUrl and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,9 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Get yours at https://aistudio.google.com/app/apikey
 GEMINI_API_KEY=your_gemini_api_key_here
 
+# Or use your own base url and api key
+# GEMINI_BASE_URL=your_gemini_base_url_here
+# GEMINI_API_KEY=your_gemini_api_key_here
+
 # Get yours at https://console.groq.com
 GROQ_API_KEY=your_groq_api_key_here

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -22,6 +22,7 @@ const anthropic = createAnthropic({
 
 const googleGenerativeAI = createGoogleGenerativeAI({
   apiKey: process.env.GEMINI_API_KEY,
+  baseURL: process.env.GEMINI_BASE_URL || "https://generativelanguage.googleapis.com/v1beta",
 });
 
 const openai = createOpenAI({


### PR DESCRIPTION
Add baseURL to Gemini client
Backward compatible when the env var is unset

baseURL: process.env.GEMINI_BASE_URL || "https://generativelanguage.googleapis.com/v1beta",