### PR TITLE
Fix typo in GROQ_API_KEY in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ VERCEL_OIDC_TOKEN=auto_generated_by_vercel_env_pull
 # VERCEL_TOKEN=vercel_xxxxxxxxxxxx   # Personal access token from Vercel dashboard
 
 # Get yours at https://console.groq.com
-GROQ_API_KEY=your_groq_api_key_here
+GROQ_API_KEY=your_groq_api_ky_here
 
 =======
 # Option 2: E2B Sandbox


### PR DESCRIPTION
Corrected a typo in the GROQ_API_KEY variable.