### PR TITLE
feat: add MiniMax provider support (M3 default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key  # Get from https://console.anthropic.c
 OPENAI_API_KEY=your_openai_api_key  # Get from https://platform.openai.com (GPT-5)
 GEMINI_API_KEY=your_gemini_api_key  # Get from https://aistudio.google.com/app/apikey
 GROQ_API_KEY=your_groq_api_key  # Get from https://console.groq.com (Fast inference - Kimi K2 recommended)
-MINIMAX_API_KEY=your_minimax_api_key  # Get from https://platform.minimax.io (MiniMax-M2.7)
+MINIMAX_API_KEY=your_minimax_api_key  # Get from https://platform.minimax.io (MiniMax-M3)
 
 # Optional Morph Fast Apply
 # Get yours at https://morphllm.com/

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key  # Get from https://console.anthropic.c
 OPENAI_API_KEY=your_openai_api_key  # Get from https://platform.openai.com (GPT-5)
 GEMINI_API_KEY=your_gemini_api_key  # Get from https://aistudio.google.com/app/apikey
 GROQ_API_KEY=your_groq_api_key  # Get from https://console.groq.com (Fast inference - Kimi K2 recommended)
+MINIMAX_API_KEY=your_minimax_api_key  # Get from https://platform.minimax.io (MiniMax-M2.7)
 
 # Optional Morph Fast Apply
 # Get yours at https://morphllm.com/

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -44,6 +44,11 @@ const openai = createOpenAI({
   baseURL: isUsingAIGateway ? aiGatewayBaseURL : process.env.OPENAI_BASE_URL,
 });
 
+const minimax = createOpenAI({
+  apiKey: process.env.MINIMAX_API_KEY,
+  baseURL: 'https://api.minimax.io/v1',
+});
+
 // Helper function to analyze user preferences from conversation history
 function analyzeUserPreferences(messages: ConversationMessage[]): {
   commonPatterns: string[];
@@ -1216,12 +1221,14 @@ MORPH FAST APPLY MODE (EDIT-ONLY):
         const isAnthropic = model.startsWith('anthropic/');
         const isGoogle = model.startsWith('google/');
         const isOpenAI = model.startsWith('openai/');
+        const isMiniMax = model.startsWith('minimax/');
         const isKimiGroq = model === 'moonshotai/kimi-k2-instruct-0905';
-        const modelProvider = isAnthropic ? anthropic : 
-                              (isOpenAI ? openai : 
-                              (isGoogle ? googleGenerativeAI : 
-                              (isKimiGroq ? groq : groq)));
-        
+        const modelProvider = isAnthropic ? anthropic :
+                              (isOpenAI ? openai :
+                              (isGoogle ? googleGenerativeAI :
+                              (isKimiGroq ? groq :
+                              (isMiniMax ? minimax : groq))));
+
         // Fix model name transformation for different providers
         let actualModel: string;
         if (isAnthropic) {
@@ -1232,13 +1239,15 @@ MORPH FAST APPLY MODE (EDIT-ONLY):
           // Kimi on Groq - use full model string
           actualModel = 'moonshotai/kimi-k2-instruct-0905';
         } else if (isGoogle) {
-          // Google uses specific model names - convert our naming to theirs  
+          // Google uses specific model names - convert our naming to theirs
           actualModel = model.replace('google/', '');
+        } else if (isMiniMax) {
+          actualModel = model.replace('minimax/', '');
         } else {
           actualModel = model;
         }
 
-        console.log(`[generate-ai-code-stream] Using provider: ${isAnthropic ? 'Anthropic' : isGoogle ? 'Google' : isOpenAI ? 'OpenAI' : 'Groq'}, model: ${actualModel}`);
+        console.log(`[generate-ai-code-stream] Using provider: ${isAnthropic ? 'Anthropic' : isGoogle ? 'Google' : isOpenAI ? 'OpenAI' : isMiniMax ? 'MiniMax' : 'Groq'}, model: ${actualModel}`);
         console.log(`[generate-ai-code-stream] AI Gateway enabled: ${isUsingAIGateway}`);
         console.log(`[generate-ai-code-stream] Model string: ${model}`);
 
@@ -1313,7 +1322,7 @@ It's better to have 3 complete files than 10 incomplete files.`
         
         // Add temperature for non-reasoning models
         if (!model.startsWith('openai/gpt-5')) {
-          streamOptions.temperature = 0.7;
+          streamOptions.temperature = isMiniMax ? 1.0 : 0.7;
         }
         
         // Add reasoning effort for GPT-5 models
@@ -1365,7 +1374,7 @@ It's better to have 3 complete files than 10 incomplete files.`
               // Final error, send to user
               await sendProgress({ 
                 type: 'error', 
-                message: `Failed to initialize ${isGoogle ? 'Gemini' : isAnthropic ? 'Claude' : isOpenAI ? 'GPT-5' : isKimiGroq ? 'Kimi (Groq)' : 'Groq'} streaming: ${streamError.message}` 
+                message: `Failed to initialize ${isGoogle ? 'Gemini' : isAnthropic ? 'Claude' : isOpenAI ? 'GPT-5' : isKimiGroq ? 'Kimi (Groq)' : isMiniMax ? 'MiniMax' : 'Groq'} streaming: ${streamError.message}`
               });
               
               // If this is a Google model error, provide helpful info

--- a/config/app.config.ts
+++ b/config/app.config.ts
@@ -58,17 +58,21 @@ export const appConfig = {
       'openai/gpt-5',
       'moonshotai/kimi-k2-instruct-0905',
       'anthropic/claude-sonnet-4-20250514',
-      'google/gemini-3-pro-preview'
+      'google/gemini-3-pro-preview',
+      'minimax/MiniMax-M2.7',
+      'minimax/MiniMax-M2.7-highspeed'
     ],
-    
+
     // Model display names
     modelDisplayNames: {
       'openai/gpt-5': 'GPT-5',
       'moonshotai/kimi-k2-instruct-0905': 'Kimi K2 (Groq)',
       'anthropic/claude-sonnet-4-20250514': 'Sonnet 4',
-      'google/gemini-3-pro-preview': 'Gemini 3 Pro (Preview)'
+      'google/gemini-3-pro-preview': 'Gemini 3 Pro (Preview)',
+      'minimax/MiniMax-M2.7': 'MiniMax-M2.7',
+      'minimax/MiniMax-M2.7-highspeed': 'MiniMax-M2.7 (High Speed)'
     } as Record<string, string>,
-    
+
     // Model API configuration
     modelApiConfig: {
       'moonshotai/kimi-k2-instruct-0905': {

--- a/config/app.config.ts
+++ b/config/app.config.ts
@@ -59,6 +59,7 @@ export const appConfig = {
       'moonshotai/kimi-k2-instruct-0905',
       'anthropic/claude-sonnet-4-20250514',
       'google/gemini-3-pro-preview',
+      'minimax/MiniMax-M3',
       'minimax/MiniMax-M2.7',
       'minimax/MiniMax-M2.7-highspeed'
     ],
@@ -69,6 +70,7 @@ export const appConfig = {
       'moonshotai/kimi-k2-instruct-0905': 'Kimi K2 (Groq)',
       'anthropic/claude-sonnet-4-20250514': 'Sonnet 4',
       'google/gemini-3-pro-preview': 'Gemini 3 Pro (Preview)',
+      'minimax/MiniMax-M3': 'MiniMax-M3',
       'minimax/MiniMax-M2.7': 'MiniMax-M2.7',
       'minimax/MiniMax-M2.7-highspeed': 'MiniMax-M2.7 (High Speed)'
     } as Record<string, string>,

--- a/lib/ai/provider-manager.ts
+++ b/lib/ai/provider-manager.ts
@@ -89,6 +89,7 @@ export function getProviderForModel(modelId: string): ProviderResolution {
   const isAnthropic = modelId.startsWith('anthropic/');
   const isOpenAI = modelId.startsWith('openai/');
   const isGoogle = modelId.startsWith('google/');
+  const isMiniMax = modelId.startsWith('minimax/');
   const isKimiGroq = modelId === 'moonshotai/kimi-k2-instruct-0905';
 
   if (isKimiGroq) {
@@ -109,6 +110,11 @@ export function getProviderForModel(modelId: string): ProviderResolution {
   if (isGoogle) {
     const client = getOrCreateClient('google');
     return { client, actualModel: modelId.replace('google/', '') };
+  }
+
+  if (isMiniMax) {
+    const client = getOrCreateClient('openai', process.env.MINIMAX_API_KEY, 'https://api.minimax.io/v1');
+    return { client, actualModel: modelId.replace('minimax/', '') };
   }
 
   // Default: use Groq with modelId as-is

--- a/packages/create-open-lovable/templates/e2b/.env.example
+++ b/packages/create-open-lovable/templates/e2b/.env.example
@@ -23,3 +23,6 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # Get yours at https://console.groq.com
 GROQ_API_KEY=your_groq_api_key_here
+
+# Get yours at https://platform.minimax.io
+MINIMAX_API_KEY=your_minimax_api_key_here

--- a/packages/create-open-lovable/templates/vercel/.env.example
+++ b/packages/create-open-lovable/templates/vercel/.env.example
@@ -26,3 +26,6 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # Get yours at https://console.groq.com
 GROQ_API_KEY=your_groq_api_key_here
+
+# Get yours at https://platform.minimax.io
+MINIMAX_API_KEY=your_minimax_api_key_here


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://platform.minimax.io) as a supported AI provider, integrating it via the OpenAI-compatible API endpoint (`https://api.minimax.io/v1`). Includes the latest **MiniMax-M3** model (default within the MiniMax provider), with MiniMax-M2.7 and MiniMax-M2.7-highspeed kept as alternatives.

### Changes

- **`config/app.config.ts`**: Added `minimax/MiniMax-M3` (placed first within the MiniMax group), `minimax/MiniMax-M2.7`, and `minimax/MiniMax-M2.7-highspeed` to `availableModels` and `modelDisplayNames`. The overall app default (`google/gemini-3-pro-preview`) is unchanged.
- **`lib/ai/provider-manager.ts`**: Added `minimax/` prefix detection; routes to an OpenAI-compatible client pointed at `https://api.minimax.io/v1` using `MINIMAX_API_KEY`.
- **`app/api/generate-ai-code-stream/route.ts`**: Added `minimax` client instance and `isMiniMax` routing; sets temperature to `1.0` (MiniMax default) instead of `0.7`.
- **`.env.example`** (root + templates): Added `MINIMAX_API_KEY` documentation.

### Configuration

Set `MINIMAX_API_KEY` in your environment to use MiniMax models. Get your key at https://platform.minimax.io.

```
MINIMAX_API_KEY=your_minimax_api_key
```

### Models

| Model ID | Display Name | Notes |
|---|---|---|
| `minimax/MiniMax-M3` | MiniMax-M3 | Latest model — 512K context, up to 128K output, image input |
| `minimax/MiniMax-M2.7` | MiniMax-M2.7 | Previous generation (kept as alternative) |
| `minimax/MiniMax-M2.7-highspeed` | MiniMax-M2.7 (High Speed) | Low-latency variant of M2.7 |