### PR TITLE
security: gate /api/* with origin check, rate limit, and optional API key (CWE-1188)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,21 @@ GROQ_API_KEY=your_groq_api_key  # Get from https://console.groq.com (Fast infere
 # Optional Morph Fast Apply
 # Get yours at https://morphllm.com/
 MORPH_API_KEY=your_fast_apply_key
+
+# =================================================================================
+# API SECURITY (CWE-1188 — denial-of-wallet protection)
+# =================================================================================
+# When set, all /api/* requests must include this key via either
+#   x-api-key: <key>            or
+#   Authorization: Bearer <key>
+# If unset, no API key is required (preserving local-dev UX). Origin checks
+# and rate limiting still apply in either case.
+# APP_API_KEY=change_me
+
+# Per-IP, per-route rate limit (defaults: 30 requests / 60s window).
+# RATE_LIMIT_MAX=30
+# RATE_LIMIT_WINDOW_MS=60000
+
+# Comma-separated extra origins permitted to call /api/* (in addition to the
+# request's own host). Useful for staging / preview deployments.
+# ALLOWED_ORIGINS=https://staging.example.com,https://preview.example.com

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,184 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Security middleware for /api/* routes.
+ *
+ * Rationale (CWE-1188 / denial-of-wallet):
+ *   The /api routes drive third-party services (Vercel/E2B sandboxes, AI
+ *   providers, Firecrawl) using the operator's API credentials. Without any
+ *   gating, an unauthenticated attacker can freely create sandboxes, install
+ *   npm packages, run commands, scrape URLs, and stream LLM tokens, all
+ *   billed to the operator. This middleware adds three lightweight layers:
+ *
+ *     1. Same-origin / allow-list check on cross-site requests
+ *     2. In-memory per-IP rate limiting
+ *     3. Optional API key (header `x-api-key` or `Authorization: Bearer ...`)
+ *
+ * All limits are configurable via env vars and the middleware is intentionally
+ * permissive in local-dev defaults so it does not break `pnpm dev`.
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const RATE_LIMIT_WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS ?? 60_000);
+const RATE_LIMIT_MAX = Number(process.env.RATE_LIMIT_MAX ?? 30);
+
+// Comma-separated list of additional allowed origins (e.g. for staging URLs).
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+// If set, requests must present this key via `x-api-key` or
+// `Authorization: Bearer <key>`. If unset, no API key is required (preserves
+// current local-dev UX) but rate limiting and origin checks still apply.
+const APP_API_KEY = process.env.APP_API_KEY;
+
+// Routes that should be reachable without auth (none today, but hook for future).
+const PUBLIC_API_PATHS = new Set<string>([]);
+
+// ---------------------------------------------------------------------------
+// Rate limiter (in-memory, per-instance)
+// ---------------------------------------------------------------------------
+
+type Bucket = { count: number; resetAt: number };
+const buckets = new Map<string, Bucket>();
+
+function rateLimit(key: string): { ok: boolean; retryAfter: number } {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+  if (!bucket || bucket.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { ok: true, retryAfter: 0 };
+  }
+  bucket.count += 1;
+  if (bucket.count > RATE_LIMIT_MAX) {
+    return { ok: false, retryAfter: Math.ceil((bucket.resetAt - now) / 1000) };
+  }
+  return { ok: true, retryAfter: 0 };
+}
+
+// Best-effort cleanup so the map does not grow unbounded.
+function maybeSweep() {
+  if (buckets.size < 1024) return;
+  const now = Date.now();
+  for (const [k, v] of buckets) if (v.resetAt <= now) buckets.delete(k);
+}
+
+function clientIp(req: NextRequest): string {
+  const xff = req.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0].trim();
+  return req.headers.get('x-real-ip') ?? '127.0.0.1';
+}
+
+// ---------------------------------------------------------------------------
+// Origin check
+// ---------------------------------------------------------------------------
+
+function isSameOrigin(req: NextRequest): boolean {
+  const origin = req.headers.get('origin');
+  const referer = req.headers.get('referer');
+  // Non-browser callers (curl, server-to-server) typically omit Origin/Referer.
+  // Allow them through – they will still need the API key when APP_API_KEY is
+  // configured. The Origin check exists primarily to defeat CSRF from
+  // arbitrary websites in a logged-in user's browser.
+  if (!origin && !referer) return true;
+
+  const host = req.headers.get('host');
+  const candidates = [
+    host ? `http://${host}` : null,
+    host ? `https://${host}` : null,
+    ...ALLOWED_ORIGINS,
+  ].filter(Boolean) as string[];
+
+  const matches = (value: string | null) => {
+    if (!value) return true;
+    try {
+      const u = new URL(value);
+      return candidates.some((c) => {
+        try {
+          const cu = new URL(c);
+          return cu.origin === u.origin;
+        } catch {
+          return false;
+        }
+      });
+    } catch {
+      return false;
+    }
+  };
+
+  return matches(origin) && matches(referer);
+}
+
+// ---------------------------------------------------------------------------
+// API key check
+// ---------------------------------------------------------------------------
+
+function hasValidApiKey(req: NextRequest): boolean {
+  if (!APP_API_KEY) return true; // not configured → not required
+  const headerKey = req.headers.get('x-api-key');
+  if (headerKey && timingSafeEqual(headerKey, APP_API_KEY)) return true;
+  const auth = req.headers.get('authorization');
+  if (auth?.startsWith('Bearer ')) {
+    return timingSafeEqual(auth.slice(7), APP_API_KEY);
+  }
+  return false;
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+// ---------------------------------------------------------------------------
+// Middleware entrypoint
+// ---------------------------------------------------------------------------
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (PUBLIC_API_PATHS.has(pathname)) return NextResponse.next();
+
+  if (!isSameOrigin(req)) {
+    return NextResponse.json(
+      { error: 'Forbidden: cross-origin request blocked' },
+      { status: 403 }
+    );
+  }
+
+  const ip = clientIp(req);
+  const { ok, retryAfter } = rateLimit(`${ip}:${pathname}`);
+  maybeSweep();
+  if (!ok) {
+    return NextResponse.json(
+      { error: 'Too Many Requests' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfter),
+          'X-RateLimit-Limit': String(RATE_LIMIT_MAX),
+          'X-RateLimit-Window': String(RATE_LIMIT_WINDOW_MS),
+        },
+      }
+    );
+  }
+
+  if (!hasValidApiKey(req)) {
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 401, headers: { 'WWW-Authenticate': 'Bearer' } }
+    );
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  // Apply only to API routes. Static assets and pages are unaffected.
+  matcher: ['/api/:path*'],
+};


### PR DESCRIPTION
## Summary

The `/api/*` routes in Open Lovable are unauthenticated and drive paid third-party services (E2B/Vercel sandboxes, OpenAI/Anthropic/Gemini, Firecrawl) using the operator's credentials. Anyone who can reach a deployed instance can create sandboxes, install npm packages, run shell commands, scrape URLs, and stream LLM tokens — all billed to the operator. This is a denial-of-wallet exposure (CWE-1188: insecure default initialization of resource).

The README documents production deployment (it explicitly mentions a Vercel PAT "for production"), so publicly reachable instances are a realistic scenario.

This PR adds a small Next.js `middleware.ts` that gates `/api/*` with three lightweight layers, all configurable via env vars and intentionally permissive by default so `pnpm dev` keeps working unchanged.

## Vulnerability details

- **CWE:** CWE-1188 (insecure default initialization) / denial-of-wallet
- **Affected surface:** all handlers under `app/api/**` — e.g. `create-ai-sandbox`, `run-command`, `install-packages`, `scrape-url-enhanced`, `generate-ai-code-stream`
- **Data flow:** unauthenticated HTTP request → API route handler → external paid provider SDK (E2B/Vercel sandbox creation, AI token generation, Firecrawl scrape) using server-side keys from `.env`
- **Preconditions:** the instance is reachable by the attacker and the operator has configured at least one paid provider (which is required for the app to do anything useful)

## Fix

A new `middleware.ts` (matched only against `/api/:path*`) applies, in order:

1. **Origin allow-list / same-origin check.** Browser requests must have an `Origin`/`Referer` matching the request `Host` or one of `ALLOWED_ORIGINS`. Cross-site requests from arbitrary websites are rejected with 403, defeating CSRF-style abuse from a victim's browser.
2. **Per-IP, per-path rate limit.** In-memory token buckets, default 30 requests / 60 s, configurable via `RATE_LIMIT_MAX` and `RATE_LIMIT_WINDOW_MS`. Bounded with a periodic sweep so the map cannot grow unbounded.
3. **Optional shared API key.** If `APP_API_KEY` is set, requests must present it via `x-api-key: <key>` or `Authorization: Bearer <key>`, compared with a constant-time check. If unset, no key is required — preserving the current local-dev experience.

`.env.example` is updated to document `APP_API_KEY`, `RATE_LIMIT_MAX`, `RATE_LIMIT_WINDOW_MS`, and `ALLOWED_ORIGINS`, all commented out.

Diff is intentionally minimal — one new file plus env docs, no changes to existing routes:

```
 .env.example  |  18 ++++++
 middleware.ts | 184 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 202 insertions(+)
```

## What we tested

- Verified the middleware compiles under the project's TypeScript config and the `matcher` correctly scopes to `/api/*` (pages and static assets are untouched).
- With `APP_API_KEY` unset (default): same-origin browser requests pass; a request with `Origin: https://evil.example` is rejected with 403; bursts above the configured limit return 429 with `Retry-After`.
- With `APP_API_KEY` set: requests without the key return 401 with `WWW-Authenticate: Bearer`; requests with `x-api-key` or `Authorization: Bearer <key>` pass; the comparison is constant-time so timing oracles don't leak the key.
- Local `pnpm dev` flow is unchanged — defaults intentionally don't require any new env var.

## Security analysis

The fix raises the cost of abuse meaningfully:

- For browser-based CSRF from a third-party site (a logged-in operator visits an attacker page that POSTs to their deployed instance), the Origin check alone blocks it.
- For deployments that set `APP_API_KEY`, unauthenticated abuse is fully blocked — this is the recommended production configuration and is now documented.
- For deployments that don't set `APP_API_KEY`, the rate limiter still caps how much damage a single IP can do per minute.

Honest caveats worth flagging:

- The in-memory rate limiter is per-instance, so multi-region deployments share no state. For Vercel, a Redis-backed limiter (e.g. Upstash) would be stronger; that's a follow-up rather than a blocker.
- `x-forwarded-for` is trusted as-is. On Vercel/most PaaS this is fine because the platform sets it; on self-hosted setups behind an untrusted proxy it could be spoofed to defeat rate-limiting.
- Defaults are permissive (no `APP_API_KEY` required) to avoid breaking existing users. Making auth required by default would be a stronger posture but a bigger UX change — happy to do that in a follow-up if you'd prefer.

## Adversarial review

Before submitting, we tried to disprove this. The questions we asked: is there an existing auth layer we missed (no — `app/api/**` route handlers contain no auth checks and there is no middleware in the repo today); is the deployment scenario realistic (yes — the README documents production deployment with a Vercel PAT); does Next.js or Vercel provide automatic protection (no — Vercel does not gate user routes, and the API routes are explicitly designed to be called from the app's own client). We also considered whether the fix could break the existing UX and chose permissive defaults specifically so it doesn't.

cc @lewiswigmore
