### PR TITLE
fix(e2b): prevent Python code injection via unescaped path/directory in runCode

### DIFF
--- a/lib/sandbox/providers/e2b-provider.ts
+++ b/lib/sandbox/providers/e2b-provider.ts
@@ -119,17 +119,21 @@ export class E2BProvider extends SandboxProvider {
       await (this.sandbox as any).files.write(fullPath, Buffer.from(content));
     } else {
       // Fallback to Python code execution
+      // Use JSON.stringify on path/content to safely encode them as Python string literals
+      // (JSON string syntax is a subset of Python string syntax), preventing code injection.
+      const pyPath = JSON.stringify(fullPath);
+      const pyContent = JSON.stringify(content);
       await this.sandbox.runCode(`
         import os
 
         # Ensure directory exists
-        dir_path = os.path.dirname("${fullPath}")
+        dir_path = os.path.dirname(${pyPath})
         os.makedirs(dir_path, exist_ok=True)
 
         # Write file
-        with open("${fullPath}", 'w') as f:
-            f.write(${JSON.stringify(content)})
-        print(f"✓ Written: ${fullPath}")
+        with open(${pyPath}, 'w') as f:
+            f.write(${pyContent})
+        print("\u2713 Written: " + ${pyPath})
       `);
     }
     
@@ -142,9 +146,17 @@ export class E2BProvider extends SandboxProvider {
     }
 
     const fullPath = path.startsWith('/') ? path : `/home/user/app/${path}`;
-    
+
+    // Prefer the E2B filesystem API to avoid string-interpolating untrusted paths into Python source.
+    if ((this.sandbox as any).files && typeof (this.sandbox as any).files.read === 'function') {
+      const content = await (this.sandbox as any).files.read(fullPath);
+      return typeof content === 'string' ? content : Buffer.from(content).toString('utf-8');
+    }
+
+    // Fallback: encode path as a JSON string literal (safe Python string literal subset).
+    const pyPath = JSON.stringify(fullPath);
     const result = await this.sandbox.runCode(`
-      with open("${fullPath}", 'r') as f:
+      with open(${pyPath}, 'r') as f:
           content = f.read()
       print(content)
     `);
@@ -171,7 +183,7 @@ export class E2BProvider extends SandboxProvider {
                   files.append(rel_path)
           return files
 
-      files = list_files("${directory}")
+      files = list_files(${JSON.stringify(directory)})
       print(json.dumps(files))
     `);
     


### PR DESCRIPTION
## Summary

`E2BProvider.writeFile`, `readFile`, and `listFiles` (in `lib/sandbox/providers/e2b-provider.ts`) build Python source by string-interpolating a file path / directory directly into the script that is then executed with `sandbox.runCode(...)`. Because these path values originate from request bodies and AI-generated output flowing in from API routes (e.g. `/api/apply-ai-code-stream`, `/api/install-packages`) without sanitization, a crafted path can break out of the surrounding Python string literal and execute arbitrary Python inside the E2B sandbox.

- **Type:** Code Injection (CWE-94)
- **Affected file:** `lib/sandbox/providers/e2b-provider.ts`
- **Affected functions:** `writeFile`, `readFile`, `listFiles`

### Vulnerable pattern (before)

```ts
await this.sandbox.runCode(`
  with open("${fullPath}", 'r') as f:
      content = f.read()
  print(content)
`);
```

A `fullPath` value such as `a", 'r'); __import__('os').system('id'); #` closes the string literal and appends attacker-chosen Python.

### Data flow

1. Client calls an unauthenticated route (e.g. `POST /api/apply-ai-code-stream`) or AI output produces a file path.
2. The path is forwarded into `E2BProvider.writeFile(path, content)` / `readFile(path)` / `listFiles(directory)`.
3. The provider concatenates that path into a Python program and calls `sandbox.runCode(...)`, executing whatever Python the attacker injected within the per-session E2B sandbox.

## Fix

Two complementary changes, both minimal:

1. **Encode interpolated values as Python string literals using `JSON.stringify`.** JSON string syntax is a strict subset of Python string syntax, so `JSON.stringify(fullPath)` produces a valid, properly-escaped Python string literal that cannot terminate early or introduce new statements. This is applied to every `runCode` site that previously interpolated user-influenced data (`writeFile` path + content, `readFile` path, `listFiles` directory).
2. **Prefer the native E2B filesystem API for `readFile`** (mirroring what `writeFile` already does), so the safe code path doesn't go through `runCode` at all when `sandbox.files.read` is available. The Python fallback remains, but is now properly escaped.

The diff is 19 additions / 7 deletions in a single file; no behavior change for legitimate inputs.

## Why this is exploitable

- The calling routes (`/api/apply-ai-code-stream`, `/api/install-packages`, etc.) have no authentication or authorization checks — anyone who can reach the deployment can drive these paths.
- There is no allowlist, normalization, or quoting on the path before it reaches `runCode`.
- The remaining `runCode` calls in `e2b-provider.ts` use static Python with no interpolation and are unaffected.

Impact is bounded by the E2B sandbox (per-session, ephemeral container), so this isn't host RCE on the Open Lovable server. It is, however, a real capability uplift: from "write/read files the app already supports" to "execute arbitrary Python in the sandbox," which includes outbound network requests, reading any file the sandbox process can see (including injected secrets/env), and tampering with other files in the session.

## Testing

- Re-read all `runCode` call sites in `e2b-provider.ts` to confirm only the three previously-interpolated sites needed changes; the rest are static strings.
- Verified `JSON.stringify` output (e.g. `a"); x=1 #` → `"a\"); x=1 #"`) parses as a single Python string literal, matching JSON's string grammar (a subset of Python's).
- Confirmed `writeFile` already had a working `sandbox.files.write` fast path; mirrored that in `readFile` for symmetry and to avoid `runCode` entirely on modern E2B SDKs.
- TypeScript change is local and type-preserving; no API surface change.

## Adversarial review

Before submitting we tried to talk ourselves out of this. The two questions worth asking are (a) "is the input really attacker-controlled?" and (b) "does the sandbox boundary make this not worth fixing?". For (a), the paths flow from unauthenticated API routes and from AI output that itself is shaped by user prompts — there is no validation between request and `runCode`. For (b), the sandbox does contain blast radius, but escaping a constrained file API into arbitrary Python execution inside that sandbox is still a meaningful uplift (network egress, secret exfiltration from the sandbox env, cross-file tampering within the session), and the fix is a 19-line, behavior-preserving change. We didn't find a reason to leave it.

cc @lewiswigmore
