### PR TITLE
test: add unit tests for lib/build-validator.ts

### DIFF
--- a/.auto-pr/SPEC.md
+++ b/.auto-pr/SPEC.md
@@ -1,0 +1,26 @@
+# Spec: Add unit tests for lib/build-validator.ts
+
+## Problem
+`lib/build-validator.ts` exports several functions used throughout the generation pipeline but has zero test coverage. The pure helper functions (`extractMissingPackages`, `classifyError`, `calculateRetryDelay`) are entirely side-effect-free and trivially testable.
+
+## Acceptance criteria
+- [ ] `extractMissingPackages` correctly parses all three error message patterns
+- [ ] `classifyError` maps error messages to the right `ErrorType`
+- [ ] `calculateRetryDelay` returns expected delays for each error type and attempt number
+- [ ] `validateBuild` is covered via a mocked `fetch` (success path + error paths)
+- [ ] Tests run via `bun test` with exit code 0
+
+## Approach
+1. Create `lib/build-validator.test.ts` using Bun's built-in test runner (`bun:test`)
+2. Use `mock.module` / `spyOn` for the `fetch` calls in `validateBuild`
+3. No new npm dependencies required
+
+## Files touched
+- `lib/build-validator.test.ts` (new)
+- `package.json` — add `"test": "bun test"` script
+
+## Risk / blast radius
+Zero — test-only addition, no production code changes.
+
+## Test plan
+- `bun test lib/build-validator.test.ts` must pass all assertions

--- a/.auto-pr/target-repo.txt
+++ b/.auto-pr/target-repo.txt
@@ -1,0 +1,1 @@
+firecrawl/open-lovable

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "open-lovable",
@@ -78,6 +79,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "bun-types": "^1.3.13",
         "eslint": "^9",
         "eslint-config-next": "15.4.3",
         "postcss": "^8.5.6",
@@ -470,6 +472,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, ""],
 
     "browserslist": ["browserslist@4.25.1", "", { "dependencies": { "caniuse-lite": "^1.0.30001726", "electron-to-chromium": "^1.5.173", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": "cli.js" }, "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, ""],
 

--- a/lib/build-validator.test.ts
+++ b/lib/build-validator.test.ts
@@ -1,0 +1,245 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn, jest } from "bun:test";
+import {
+  extractMissingPackages,
+  classifyError,
+  calculateRetryDelay,
+  validateBuild,
+} from "./build-validator";
+
+// ---------------------------------------------------------------------------
+// extractMissingPackages
+// ---------------------------------------------------------------------------
+describe("extractMissingPackages", () => {
+  test("pattern 1: Failed to resolve import (double quotes)", () => {
+    expect(extractMissingPackages(new Error('Failed to resolve import "react-icons"'))).toEqual(["react-icons"]);
+  });
+
+  test("pattern 1: Failed to resolve import (single quotes)", () => {
+    expect(extractMissingPackages(new Error("Failed to resolve import 'lodash'"))).toEqual(["lodash"]);
+  });
+
+  test("pattern 2: Cannot find module", () => {
+    expect(extractMissingPackages(new Error("Cannot find module 'some-pkg'"))).toEqual(["some-pkg"]);
+  });
+
+  test("pattern 3: Package not found", () => {
+    expect(extractMissingPackages(new Error("Package 'my-lib' not found"))).toEqual(["my-lib"]);
+  });
+
+  test("deduplicates packages", () => {
+    const err = new Error('Failed to resolve import "react-icons"\nFailed to resolve import "react-icons"');
+    expect(extractMissingPackages(err)).toEqual(["react-icons"]);
+  });
+
+  test("extracts multiple distinct packages", () => {
+    const err = new Error('Failed to resolve import "pkg-a"\nCannot find module \'pkg-b\'');
+    expect(extractMissingPackages(err)).toEqual(["pkg-a", "pkg-b"]);
+  });
+
+  test("returns empty array when no pattern matches", () => {
+    expect(extractMissingPackages(new Error("unrelated error"))).toEqual([]);
+  });
+
+  test("handles non-Error string via String()", () => {
+    expect(extractMissingPackages("Cannot find module 'inline-pkg'")).toEqual(["inline-pkg"]);
+  });
+
+  test("handles object with message property", () => {
+    expect(extractMissingPackages({ message: "Package 'custom' not found" })).toEqual(["custom"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyError
+// ---------------------------------------------------------------------------
+describe("classifyError", () => {
+  test("missing-package: Failed to resolve import", () => {
+    expect(classifyError(new Error("Failed to resolve import 'x'"))).toBe("missing-package");
+  });
+
+  test("missing-package: Cannot find module", () => {
+    expect(classifyError(new Error("Cannot find module 'y'"))).toBe("missing-package");
+  });
+
+  test("missing-package: Missing package", () => {
+    expect(classifyError(new Error("Missing package: z"))).toBe("missing-package");
+  });
+
+  test("syntax-error: syntax error", () => {
+    expect(classifyError(new Error("SyntaxError: unexpected token"))).toBe("syntax-error");
+  });
+
+  test("syntax-error: parsing error", () => {
+    expect(classifyError(new Error("parsing error at line 5"))).toBe("syntax-error");
+  });
+
+  test("sandbox-timeout: timed out", () => {
+    expect(classifyError(new Error("Request timed out"))).toBe("sandbox-timeout");
+  });
+
+  test("sandbox-timeout: not responding", () => {
+    expect(classifyError(new Error("Sandbox not responding"))).toBe("sandbox-timeout");
+  });
+
+  test("not-rendered: default page", () => {
+    expect(classifyError(new Error("Sandbox showing default page"))).toBe("not-rendered");
+  });
+
+  test("not-rendered: app not rendered", () => {
+    expect(classifyError(new Error("App not rendered yet"))).toBe("not-rendered");
+  });
+
+  test("vite-error: vite keyword", () => {
+    expect(classifyError(new Error("Vite compilation failed"))).toBe("vite-error");
+  });
+
+  test("vite-error: compilation keyword", () => {
+    expect(classifyError(new Error("compilation error detected"))).toBe("vite-error");
+  });
+
+  test("unknown: unrecognized message", () => {
+    expect(classifyError(new Error("some completely unrelated message"))).toBe("unknown");
+  });
+
+  test("case-insensitive matching", () => {
+    expect(classifyError(new Error("SYNTAX ERROR in file"))).toBe("syntax-error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateRetryDelay
+// ---------------------------------------------------------------------------
+describe("calculateRetryDelay", () => {
+  const BASE = 2000;
+
+  test("missing-package: 2× base × attempt", () => {
+    expect(calculateRetryDelay(1, "missing-package")).toBe(BASE * 2 * 1); // 4000
+    expect(calculateRetryDelay(3, "missing-package")).toBe(BASE * 2 * 3); // 12000
+  });
+
+  test("not-rendered: 3× base × attempt", () => {
+    expect(calculateRetryDelay(1, "not-rendered")).toBe(BASE * 3 * 1); // 6000
+    expect(calculateRetryDelay(2, "not-rendered")).toBe(BASE * 3 * 2); // 12000
+  });
+
+  test("vite-error: 2× base × attempt", () => {
+    expect(calculateRetryDelay(1, "vite-error")).toBe(BASE * 2 * 1); // 4000
+    expect(calculateRetryDelay(4, "vite-error")).toBe(BASE * 2 * 4); // 16000
+  });
+
+  test("sandbox-timeout: 4× base × attempt", () => {
+    expect(calculateRetryDelay(1, "sandbox-timeout")).toBe(BASE * 4 * 1); // 8000
+    expect(calculateRetryDelay(2, "sandbox-timeout")).toBe(BASE * 4 * 2); // 16000
+  });
+
+  test("unknown falls through to base × attempt", () => {
+    expect(calculateRetryDelay(1, "unknown")).toBe(BASE * 1); // 2000
+    expect(calculateRetryDelay(3, "unknown")).toBe(BASE * 3); // 6000
+  });
+
+  test("syntax-error falls through to base × attempt", () => {
+    expect(calculateRetryDelay(2, "syntax-error")).toBe(BASE * 2); // 4000
+  });
+
+  test("delay scales linearly with attempt", () => {
+    const delay1 = calculateRetryDelay(1, "missing-package");
+    const delay2 = calculateRetryDelay(2, "missing-package");
+    expect(delay2).toBe(delay1 * 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateBuild
+// ---------------------------------------------------------------------------
+describe("validateBuild", () => {
+  function mockFetch(status: number, body: string) {
+    return spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => body,
+    } as Response);
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  async function runWithTimers<T>(fn: () => Promise<T>): Promise<T> {
+    const promise = fn();
+    jest.runAllTimers();
+    return promise;
+  }
+
+  test("returns success when app renders correctly", async () => {
+    const spy = mockFetch(200, '<div id="root"><app /></div>');
+    const result = await runWithTimers(() => validateBuild("https://sandbox.test", "sid"));
+    expect(result.success).toBe(true);
+    expect(result.isRendering).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    spy.mockRestore();
+  });
+
+  test("returns failure when sandbox responds with non-OK status", async () => {
+    const spy = mockFetch(503, "");
+    const result = await runWithTimers(() => validateBuild("https://sandbox.test", "sid"));
+    expect(result.success).toBe(false);
+    expect(result.isRendering).toBe(false);
+    expect(result.errors[0]).toContain("503");
+    spy.mockRestore();
+  });
+
+  test("detects default Vite + React page", async () => {
+    const spy = mockFetch(200, "<html><body>Vite + React</body></html>");
+    const result = await runWithTimers(() => validateBuild("https://sandbox.test", "sid"));
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain("default page");
+    spy.mockRestore();
+  });
+
+  test("detects Vercel Sandbox Ready page", async () => {
+    const spy = mockFetch(200, "<html>Vercel Sandbox Ready</html>");
+    const result = await runWithTimers(() => validateBuild("https://sandbox.test", "sid"));
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain("default page");
+    spy.mockRestore();
+  });
+
+  test("detects page missing root element", async () => {
+    const spy = mockFetch(200, "<html><body>no root div here</body></html>");
+    const result = await runWithTimers(() => validateBuild("https://sandbox.test", "sid"));
+    expect(result.success).toBe(false);
+    spy.mockRestore();
+  });
+
+  test("detects vite-error-overlay with generic error", async () => {
+    const spy = mockFetch(200, '<div id="root"></div><vite-error-overlay></vite-error-overlay>');
+    const result = await runWithTimers(() => validateBuild("https://sandbox.test", "sid"));
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toBe("Vite compilation error detected");
+    spy.mockRestore();
+  });
+
+  test("extracts missing package name from vite-error-overlay", async () => {
+    const body = `<div id="root"></div><vite-error-overlay>Failed to resolve import "react-confetti"</vite-error-overlay>`;
+    const spy = mockFetch(200, body);
+    const result = await runWithTimers(() => validateBuild("https://sandbox.test", "sid"));
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toBe("Missing package: react-confetti");
+    spy.mockRestore();
+  });
+
+  test("returns failure on network error", async () => {
+    const spy = spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network failure"));
+    const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
+    const result = await runWithTimers(() => validateBuild("https://sandbox.test", "sid"));
+    expect(result.success).toBe(false);
+    expect(result.isRendering).toBe(false);
+    expect(result.errors[0]).toBe("Network failure");
+    spy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "bun test",
     "test:api": "node tests/api-endpoints.test.js",
     "test:code": "node tests/code-execution.test.js",
     "test:all": "npm run test:integration && npm run test:api && npm run test:code"
@@ -87,6 +88,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "bun-types": "^1.3.13",
     "eslint": "^9",
     "eslint-config-next": "15.4.3",
     "postcss": "^8.5.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "examples", "tests", "lib/e2b-backends/archive", "styles"]
+  "exclude": ["node_modules", "examples", "tests", "lib/e2b-backends/archive", "styles", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary

- Adds `lib/build-validator.test.ts` with 37 tests covering all exported functions in `lib/build-validator.ts`
- Adds `bun-types` as a dev dependency so `bun:test` imports resolve correctly
- Excludes `*.test.ts` files from the Next.js `tsconfig.json` to avoid type conflicts; adds a `tsconfig.test.json` for test-specific type checking
- Adds `"test": "bun test"` script to `package.json`

## Coverage

| Function | Cases covered |
|---|---|
| `extractMissingPackages` | all 3 regex patterns, dedup, non-Error inputs, empty result |
| `classifyError` | all 6 error types + case-insensitivity |
| `calculateRetryDelay` | all 5 switch branches, linear scaling |
| `validateBuild` | success, 503, default page, vite-error-overlay, missing package extraction, network error |

## Test run

```
bun test lib/build-validator.test.ts
 37 pass
 0 fail
 52 expect() calls
Ran 37 tests across 1 file. [10.00ms]
```

No production code was modified.