### PR TITLE
Add SiliconFlow provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,8 @@ ANTHROPIC_API_KEY=your_anthropic_api_key  # Get from https://console.anthropic.c
 OPENAI_API_KEY=your_openai_api_key  # Get from https://platform.openai.com (GPT-5)
 GEMINI_API_KEY=your_gemini_api_key  # Get from https://aistudio.google.com/app/apikey
 GROQ_API_KEY=your_groq_api_key  # Get from https://console.groq.com (Fast inference - Kimi K2 recommended)
+SILICONFLOW_API_KEY=your_siliconflow_api_key  # Get from https://cloud.siliconflow.cn/account/ak
+SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1
 
 # Optional Morph Fast Apply
 # Get yours at https://morphllm.com/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ GEMINI_API_KEY=your_gemini_api_key        # https://aistudio.google.com/app/apik
 ANTHROPIC_API_KEY=your_anthropic_api_key  # https://console.anthropic.com
 OPENAI_API_KEY=your_openai_api_key        # https://platform.openai.com
 GROQ_API_KEY=your_groq_api_key            # https://console.groq.com
+SILICONFLOW_API_KEY=your_siliconflow_api_key  # https://cloud.siliconflow.cn/account/ak
+SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1
 
 # =================================================================
 # FAST APPLY (Optional - for faster edits)

--- a/app/api/analyze-edit-intent/route.ts
+++ b/app/api/analyze-edit-intent/route.ts
@@ -26,6 +26,11 @@ const openai = createOpenAI({
   baseURL: isUsingAIGateway ? aiGatewayBaseURL : process.env.OPENAI_BASE_URL,
 });
 
+const siliconflow = createOpenAI({
+  apiKey: process.env.SILICONFLOW_API_KEY,
+  baseURL: process.env.SILICONFLOW_BASE_URL || 'https://api.siliconflow.cn/v1',
+});
+
 const googleGenerativeAI = createGoogleGenerativeAI({
   apiKey: process.env.AI_GATEWAY_API_KEY ?? process.env.GEMINI_API_KEY,
   baseURL: isUsingAIGateway ? aiGatewayBaseURL : undefined,
@@ -113,6 +118,8 @@ export async function POST(request: NextRequest) {
       } else {
         aiModel = openai(model.replace('openai/', ''));
       }
+    } else if (model.startsWith('siliconflow/')) {
+      aiModel = siliconflow(model.replace('siliconflow/', ''));
     } else if (model.startsWith('google/')) {
       aiModel = googleGenerativeAI(model.replace('google/', ''));
     } else {

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -44,6 +44,11 @@ const openai = createOpenAI({
   baseURL: isUsingAIGateway ? aiGatewayBaseURL : process.env.OPENAI_BASE_URL,
 });
 
+const siliconflow = createOpenAI({
+  apiKey: process.env.SILICONFLOW_API_KEY,
+  baseURL: process.env.SILICONFLOW_BASE_URL || 'https://api.siliconflow.cn/v1',
+});
+
 // Helper function to analyze user preferences from conversation history
 function analyzeUserPreferences(messages: ConversationMessage[]): {
   commonPatterns: string[];
@@ -1216,11 +1221,13 @@ MORPH FAST APPLY MODE (EDIT-ONLY):
         const isAnthropic = model.startsWith('anthropic/');
         const isGoogle = model.startsWith('google/');
         const isOpenAI = model.startsWith('openai/');
+        const isSiliconFlow = model.startsWith('siliconflow/');
         const isKimiGroq = model === 'moonshotai/kimi-k2-instruct-0905';
         const modelProvider = isAnthropic ? anthropic : 
                               (isOpenAI ? openai : 
+                              (isSiliconFlow ? siliconflow :
                               (isGoogle ? googleGenerativeAI : 
-                              (isKimiGroq ? groq : groq)));
+                              (isKimiGroq ? groq : groq))));
         
         // Fix model name transformation for different providers
         let actualModel: string;
@@ -1228,6 +1235,8 @@ MORPH FAST APPLY MODE (EDIT-ONLY):
           actualModel = model.replace('anthropic/', '');
         } else if (isOpenAI) {
           actualModel = model.replace('openai/', '');
+        } else if (isSiliconFlow) {
+          actualModel = model.replace('siliconflow/', '');
         } else if (isKimiGroq) {
           // Kimi on Groq - use full model string
           actualModel = 'moonshotai/kimi-k2-instruct-0905';
@@ -1238,7 +1247,7 @@ MORPH FAST APPLY MODE (EDIT-ONLY):
           actualModel = model;
         }
 
-        console.log(`[generate-ai-code-stream] Using provider: ${isAnthropic ? 'Anthropic' : isGoogle ? 'Google' : isOpenAI ? 'OpenAI' : 'Groq'}, model: ${actualModel}`);
+        console.log(`[generate-ai-code-stream] Using provider: ${isAnthropic ? 'Anthropic' : isGoogle ? 'Google' : isOpenAI ? 'OpenAI' : isSiliconFlow ? 'SiliconFlow' : 'Groq'}, model: ${actualModel}`);
         console.log(`[generate-ai-code-stream] AI Gateway enabled: ${isUsingAIGateway}`);
         console.log(`[generate-ai-code-stream] Model string: ${model}`);
 
@@ -1365,7 +1374,7 @@ It's better to have 3 complete files than 10 incomplete files.`
               // Final error, send to user
               await sendProgress({ 
                 type: 'error', 
-                message: `Failed to initialize ${isGoogle ? 'Gemini' : isAnthropic ? 'Claude' : isOpenAI ? 'GPT-5' : isKimiGroq ? 'Kimi (Groq)' : 'Groq'} streaming: ${streamError.message}` 
+                message: `Failed to initialize ${isGoogle ? 'Gemini' : isAnthropic ? 'Claude' : isOpenAI ? 'GPT-5' : isSiliconFlow ? 'SiliconFlow' : isKimiGroq ? 'Kimi (Groq)' : 'Groq'} streaming: ${streamError.message}` 
               });
               
               // If this is a Google model error, provide helpful info
@@ -1733,6 +1742,8 @@ Provide the complete file content without any truncation. Include all necessary 
                   completionClient = anthropic;
                 } else if (model === 'moonshotai/kimi-k2-instruct-0905') {
                   completionClient = groq;
+                } else if (model.includes('siliconflow')) {
+                  completionClient = siliconflow;
                 } else {
                   completionClient = groq;
                 }
@@ -1747,6 +1758,8 @@ Provide the complete file content without any truncation. Include all necessary 
                   completionModelName = model.replace('anthropic/', '');
                 } else if (model.includes('google')) {
                   completionModelName = model.replace('google/', '');
+                } else if (model.includes('siliconflow')) {
+                  completionModelName = model.replace('siliconflow/', '');
                 } else {
                   completionModelName = model;
                 }

--- a/config/app.config.ts
+++ b/config/app.config.ts
@@ -58,7 +58,8 @@ export const appConfig = {
       'openai/gpt-5',
       'moonshotai/kimi-k2-instruct-0905',
       'anthropic/claude-sonnet-4-20250514',
-      'google/gemini-3-pro-preview'
+      'google/gemini-3-pro-preview',
+      'siliconflow/Qwen/Qwen3.6-27B'
     ],
     
     // Model display names
@@ -66,7 +67,8 @@ export const appConfig = {
       'openai/gpt-5': 'GPT-5',
       'moonshotai/kimi-k2-instruct-0905': 'Kimi K2 (Groq)',
       'anthropic/claude-sonnet-4-20250514': 'Sonnet 4',
-      'google/gemini-3-pro-preview': 'Gemini 3 Pro (Preview)'
+      'google/gemini-3-pro-preview': 'Gemini 3 Pro (Preview)',
+      'siliconflow/Qwen/Qwen3.6-27B': 'Qwen3.6 27B (SiliconFlow)'
     } as Record<string, string>,
     
     // Model API configuration
@@ -74,6 +76,10 @@ export const appConfig = {
       'moonshotai/kimi-k2-instruct-0905': {
         provider: 'groq',
         model: 'moonshotai/kimi-k2-instruct-0905'
+      },
+      'siliconflow/Qwen/Qwen3.6-27B': {
+        provider: 'siliconflow',
+        model: 'Qwen/Qwen3.6-27B'
       }
     },
     

--- a/lib/ai/provider-manager.ts
+++ b/lib/ai/provider-manager.ts
@@ -4,7 +4,7 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 
-type ProviderName = 'openai' | 'anthropic' | 'groq' | 'google';
+type ProviderName = 'openai' | 'anthropic' | 'groq' | 'google' | 'siliconflow';
 
 // Client function type returned by @ai-sdk providers
 export type ProviderClient =
@@ -40,6 +40,8 @@ function getEnvDefaults(provider: ProviderName): { apiKey?: string; baseURL?: st
       return { apiKey: process.env.GROQ_API_KEY, baseURL: process.env.GROQ_BASE_URL };
     case 'google':
       return { apiKey: process.env.GEMINI_API_KEY, baseURL: process.env.GEMINI_BASE_URL };
+    case 'siliconflow':
+      return { apiKey: process.env.SILICONFLOW_API_KEY, baseURL: process.env.SILICONFLOW_BASE_URL || 'https://api.siliconflow.cn/v1' };
     default:
       return {};
   }
@@ -68,6 +70,9 @@ function getOrCreateClient(provider: ProviderName, apiKey?: string, baseURL?: st
     case 'google':
       client = createGoogleGenerativeAI({ apiKey: effective.apiKey || getEnvDefaults('google').apiKey, baseURL: effective.baseURL ?? getEnvDefaults('google').baseURL });
       break;
+    case 'siliconflow':
+      client = createOpenAI({ apiKey: effective.apiKey || getEnvDefaults('siliconflow').apiKey, baseURL: effective.baseURL ?? getEnvDefaults('siliconflow').baseURL });
+      break;
     default:
       client = createGroq({ apiKey: effective.apiKey || getEnvDefaults('groq').apiKey, baseURL: effective.baseURL ?? getEnvDefaults('groq').baseURL });
   }
@@ -89,6 +94,7 @@ export function getProviderForModel(modelId: string): ProviderResolution {
   const isAnthropic = modelId.startsWith('anthropic/');
   const isOpenAI = modelId.startsWith('openai/');
   const isGoogle = modelId.startsWith('google/');
+  const isSiliconFlow = modelId.startsWith('siliconflow/');
   const isKimiGroq = modelId === 'moonshotai/kimi-k2-instruct-0905';
 
   if (isKimiGroq) {
@@ -111,12 +117,16 @@ export function getProviderForModel(modelId: string): ProviderResolution {
     return { client, actualModel: modelId.replace('google/', '') };
   }
 
+  if (isSiliconFlow) {
+    const client = getOrCreateClient('siliconflow');
+    return { client, actualModel: modelId.replace('siliconflow/', '') };
+  }
+
   // Default: use Groq with modelId as-is
   const client = getOrCreateClient('groq');
   return { client, actualModel: modelId };
 }
 
 export default getProviderForModel;
-
 
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test:providers": "node tests/provider-manager-config.test.mjs",
     "test:api": "node tests/api-endpoints.test.js",
     "test:code": "node tests/code-execution.test.js",
     "test:all": "npm run test:integration && npm run test:api && npm run test:code"

--- a/packages/create-open-lovable/lib/installer.js
+++ b/packages/create-open-lovable/lib/installer.js
@@ -187,6 +187,9 @@ async function createEnvFile(projectPath, sandbox, answers) {
   } else {
     envContent += `# GROQ_API_KEY=your_groq_api_key_here\n`;
   }
+
+  envContent += `# SILICONFLOW_API_KEY=your_siliconflow_api_key_here\n`;
+  envContent += `SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1\n`;
   
   await fs.writeFile(path.join(projectPath, '.env'), envContent);
   await fs.writeFile(path.join(projectPath, '.env.example'), envContent.replace(/=.+/g, '=your_key_here'));
@@ -223,7 +226,10 @@ async function createEnvExample(projectPath, sandbox) {
   envContent += `# Get yours at https://aistudio.google.com/app/apikey\n`;
   envContent += `GEMINI_API_KEY=your_gemini_api_key_here\n\n`;
   envContent += `# Get yours at https://console.groq.com\n`;
-  envContent += `GROQ_API_KEY=your_groq_api_key_here\n`;
+  envContent += `GROQ_API_KEY=your_groq_api_key_here\n\n`;
+  envContent += `# Get yours at https://cloud.siliconflow.cn/account/ak\n`;
+  envContent += `SILICONFLOW_API_KEY=your_siliconflow_api_key_here\n`;
+  envContent += `SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1\n`;
   
   await fs.writeFile(path.join(projectPath, '.env.example'), envContent);
 }

--- a/packages/create-open-lovable/templates/e2b/.env.example
+++ b/packages/create-open-lovable/templates/e2b/.env.example
@@ -23,3 +23,7 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # Get yours at https://console.groq.com
 GROQ_API_KEY=your_groq_api_key_here
+
+# Get yours at https://cloud.siliconflow.cn/account/ak
+SILICONFLOW_API_KEY=your_siliconflow_api_key_here
+SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1

--- a/packages/create-open-lovable/templates/vercel/.env.example
+++ b/packages/create-open-lovable/templates/vercel/.env.example
@@ -26,3 +26,7 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # Get yours at https://console.groq.com
 GROQ_API_KEY=your_groq_api_key_here
+
+# Get yours at https://cloud.siliconflow.cn/account/ak
+SILICONFLOW_API_KEY=your_siliconflow_api_key_here
+SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1

--- a/tests/provider-manager-config.test.mjs
+++ b/tests/provider-manager-config.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const providerManager = readFileSync('lib/ai/provider-manager.ts', 'utf8');
+const appConfig = readFileSync('config/app.config.ts', 'utf8');
+const envExample = readFileSync('.env.example', 'utf8');
+const analyzeEditIntentRoute = readFileSync('app/api/analyze-edit-intent/route.ts', 'utf8');
+const generateCodeRoute = readFileSync('app/api/generate-ai-code-stream/route.ts', 'utf8');
+
+assert.match(providerManager, /type ProviderName = .*'siliconflow'/s);
+assert.match(providerManager, /SILICONFLOW_API_KEY/);
+assert.match(providerManager, /SILICONFLOW_BASE_URL/);
+assert.match(providerManager, /https:\/\/api\.siliconflow\.cn\/v1/);
+assert.match(providerManager, /modelId\.startsWith\('siliconflow\/'\)/);
+
+assert.match(appConfig, /'siliconflow\/Qwen\/Qwen3\.6-27B'/);
+assert.match(appConfig, /provider:\s*'siliconflow'/);
+assert.match(appConfig, /model:\s*'Qwen\/Qwen3\.6-27B'/);
+
+assert.match(envExample, /SILICONFLOW_API_KEY/);
+assert.match(envExample, /SILICONFLOW_BASE_URL/);
+
+for (const route of [analyzeEditIntentRoute, generateCodeRoute]) {
+  assert.match(route, /SILICONFLOW_API_KEY/);
+  assert.match(route, /SILICONFLOW_BASE_URL/);
+  assert.match(route, /model\.startsWith\('siliconflow\/'\)/);
+}
+
+assert.match(analyzeEditIntentRoute, /siliconflow\(model\.replace\('siliconflow\/', ''\)\)/);
+assert.match(generateCodeRoute, /isSiliconFlow \? siliconflow/);
+assert.match(generateCodeRoute, /actualModel = model\.replace\('siliconflow\/', ''\)/);
+assert.match(generateCodeRoute, /model\.includes\('siliconflow'\)/);
+assert.match(generateCodeRoute, /completionClient = siliconflow/);
+assert.match(generateCodeRoute, /completionModelName = model\.replace\('siliconflow\/', ''\)/);
+
+console.log('SiliconFlow provider configuration is present.');


### PR DESCRIPTION
## Summary

- Add SiliconFlow as an OpenAI-compatible AI provider.
- Add a SiliconFlow model to the model selector and model API config.
- Route SiliconFlow models in both edit-intent analysis and code generation flows.
- Document SiliconFlow environment variables in the root app and create-open-lovable templates.
- Add a lightweight provider configuration test that verifies SiliconFlow wiring.

## Test

```sh
node tests/provider-manager-config.test.mjs
node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('package.json','utf8')); console.log('package.json ok')"
```

Note: this environment does not have npm available, so I could not run the full Next.js lint/build scripts locally.

## Related

SiliconFlow task: https://github.com/siliconflow/siliconflow-open-source-tasks/issues/4