### PR TITLE
fix: correct github URLs, default model, and broken test:all script

### DIFF
--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -90,7 +90,7 @@ declare global {
 
 export async function POST(request: NextRequest) {
   try {
-    const { prompt, model = 'openai/gpt-oss-20b', context, isEdit = false } = await request.json();
+    const { prompt, model = 'google/gemini-3-pro-preview', context, isEdit = false } = await request.json();
     
     console.log('[generate-ai-code-stream] Received request:');
     console.log('[generate-ai-code-stream] - prompt:', prompt);

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -49,7 +49,7 @@ export default function LandingPage() {
 
               <div className="flex gap-8">
                 <Link
-                  href="https://github.com/mendableai/open-lovable"
+                  href="https://github.com/firecrawl/open-lovable"
                   target="_blank"
                   className="contents"
                 >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -238,7 +238,7 @@ export default function HomePage() {
               <div className="flex gap-8">
                 <a
                   className="contents"
-                  href="https://github.com/mendableai/open-lovable"
+                  href="https://github.com/firecrawl/open-lovable"
                   target="_blank"
                 >
                   <ButtonUI variant="tertiary">

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "test:api": "node tests/api-endpoints.test.js",
     "test:code": "node tests/code-execution.test.js",
-    "test:all": "npm run test:integration && npm run test:api && npm run test:code"
+    "test:all": "npm run test:api && npm run test:code"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.1",


### PR DESCRIPTION
Spotted a few things:

- the GitHub links in page.tsx and landing.tsx pointed to \`mendableai/open-lovable\` instead of \`firecrawl/open-lovable\`
- the default model fallback in generate-ai-code-stream was \`openai/gpt-oss-20b\` which isn't in the available models config — changed it to match the actual default from app.config.ts
- \`npm run test:all\` was referencing \`test:integration\` which doesn't exist as a script, so it always failed. removed the missing script from the chain