### PR TITLE
fix: update deprecated OpenAI fallback model

### DIFF
--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -1357,9 +1357,15 @@ It's better to have 3 complete files than 10 incomplete files.`
               
               // If Groq fails, try switching to a fallback model
               if (isGroqServiceError && retryCount === maxRetries) {
-                console.log('[generate-ai-code-stream] Groq service unavailable, falling back to GPT-4');
-                streamOptions.model = openai('gpt-4-turbo');
-                actualModel = 'gpt-4-turbo';
+                console.log('[generate-ai-code-stream] Groq service unavailable, falling back to GPT-5.5');
+                streamOptions.model = openai('gpt-5.5');
+                streamOptions.temperature = undefined;
+                streamOptions.experimental_providerMetadata = {
+                  openai: {
+                    reasoningEffort: 'high'
+                  }
+                };
+                actualModel = 'gpt-5.5';
               }
             } else {
               // Final error, send to user


### PR DESCRIPTION
## What changed

The Groq service-unavailable recovery path now falls back to `gpt-5.5` instead of `gpt-4-turbo`.

When the provider changes from Groq to OpenAI, the retry also clears `temperature` and applies OpenAI `reasoningEffort: high`. This keeps the fallback request aligned with the parameter handling already used by the route's GPT-5 path.

## Why

OpenAI has announced that `gpt-4-turbo` will be shut down on October 23, 2026 and lists `gpt-5.5` as its replacement: https://developers.openai.com/api/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots

Without this change, the emergency fallback is tied to a model with a scheduled retirement. Updating only the model string would leave the Groq request's temperature setting attached, so the provider-specific options are normalized at the same boundary.

## Impact

Normal model selection is unchanged. Only the existing Groq service-unavailable fallback uses the newer OpenAI model.

## Validation

- `npx tsc --noEmit`
- `git diff --check`

`npm ci` could not run because the repository's existing `package-lock.json` is missing optional platform packages required by the current `package.json`. I used `npm install --ignore-scripts` to install dependencies for the successful typecheck and discarded the resulting lockfile changes.

No live API request was made.
