### PR TITLE
fix(parser): stop dropping/corrupting files when a </file> tag is missing

### DIFF
--- a/app/api/apply-ai-code-stream/route.ts
+++ b/app/api/apply-ai-code-stream/route.ts
@@ -67,7 +67,7 @@ function parseAIResponse(response: string): ParsedResponse {
   const fileMap = new Map<string, { content: string; isComplete: boolean }>();
 
   // First pass: Find all file declarations
-  const fileRegex = /<file path="([^"]+)">([\s\S]*?)(?:<\/file>|$)/g;
+  const fileRegex = /<file path="([^"]+)">([\s\S]*?)(?:<\/file>|(?=<file path=")|$)/g;
   let match;
   while ((match = fileRegex.exec(response)) !== null) {
     const filePath = match[1];

--- a/app/api/apply-ai-code/route.ts
+++ b/app/api/apply-ai-code/route.ts
@@ -29,7 +29,7 @@ function parseAIResponse(response: string): ParsedResponse {
   // Parse file sections - handle duplicates and prefer complete versions
   const fileMap = new Map<string, { content: string; isComplete: boolean }>();
   
-  const fileRegex = /<file path="([^"]+)">([\s\S]*?)(?:<\/file>|$)/g;
+  const fileRegex = /<file path="([^"]+)">([\s\S]*?)(?:<\/file>|(?=<file path=")|$)/g;
   let match;
   while ((match = fileRegex.exec(response)) !== null) {
     const filePath = match[1];

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -1565,7 +1565,7 @@ It's better to have 3 complete files than 10 incomplete files.`
         }
         
         // Parse files and send progress for each
-        const fileRegex = /<file path="([^"]+)">([\s\S]*?)<\/file>/g;
+        const fileRegex = /<file path="([^"]+)">([\s\S]*?)(?:<\/file>|(?=<file path="))/g;
         const files = [];
         let match;
         


### PR DESCRIPTION
## What

Fixes the `<file>` block parser so it no longer **silently drops a file and corrupts another** when the model's output is missing a `</file>` closing tag on an earlier block.

Fixes #215

## Root cause

The parser regex

```ts
/<file path="([^"]+)">([\s\S]*?)(?:<\/file>|$)/g
```

uses a lazy body match terminated only by `</file>` or end-of-string. If an earlier `<file>` block is missing its `</file>`, the nearest `</file>` is *after a later file*, so the first capture spans across the next file's opening tag — absorbing that later file's tag + body and never emitting it. In `apply-ai-code/route.ts` the merged match ends with `</file>`, so `hasClosingTag` is `true` and the block is treated as **complete**, suppressing the truncation warning too.

## Fix

Add a `(?=<file path=")` look-ahead as an additional block terminator, so a block always ends at the next file's opening tag:

```diff
-/<file path="([^"]+)">([\s\S]*?)(?:<\/file>|$)/g
+/<file path="([^"]+)">([\s\S]*?)(?:<\/file>|(?=<file path=")|$)/g
```

Applied to the three parsers that share this regex:

- `app/api/apply-ai-code/route.ts:32`
- `app/api/apply-ai-code-stream/route.ts:70`
- `app/api/generate-ai-code-stream/route.ts:1568` (strict variant — look-ahead added, no `$` alternative so its existing "requires a closing tag" semantics are preserved)

## Verification

Parser behavior before vs. after on the same inputs:

| Input | Before | After |
|---|---|---|
| `<file path="src/A.jsx">AAA<file path="src/B.jsx">BBB</file>` (A missing `</file>`) | `[A → "AAA<file path=\"src/B.jsx\">BBB", complete]` — **B dropped, A corrupt** | `[A → "AAA" (flagged incomplete), B → "BBB"]` |
| `A</file>\nB</file>` (well-formed) | both files parsed | both files parsed — **no change** |
| `A</file>\nB` (final file truncated) | A complete, B flagged truncated | A complete, B flagged truncated — **no change** |

For well-formed input the alternation matches `</file>` first, so the behavior is unchanged; the look-ahead only changes the malformed case.
