### PR TITLE
fix(file-search): rank exact-term edit target case-insensitively

### DIFF
--- a/lib/file-search-executor.ts
+++ b/lib/file-search-executor.ts
@@ -107,7 +107,7 @@ export function executeSearchPlan(
           let confidence: 'high' | 'medium' | 'low' = 'medium';
           
           // High confidence if it's an exact match or in a component definition
-          if (matchedTerm && line.includes(matchedTerm)) {
+          if (matchedTerm && line.toLowerCase().includes(matchedTerm.toLowerCase())) {
             confidence = 'high';
           } else if (line.includes('function') || line.includes('export') || line.includes('return')) {
             confidence = 'high';


### PR DESCRIPTION
## What

Fixes edit-target ranking in `performSearch`: an exact search-term hit was sometimes left at `medium` confidence (and outranked by an unrelated line) because the confidence check re-tested the term **case-sensitively**, while the term itself is matched **case-insensitively**.

Fixes #217

## Root cause

`lib/file-search-executor.ts` matches terms case-insensitively:

```ts
if (line.toLowerCase().includes(term.toLowerCase())) { ... matchedTerm = term; }
```

but the confidence check re-tested case-sensitively:

```ts
if (matchedTerm && line.includes(matchedTerm)) { confidence = 'high'; }
else if (line.includes('function') || line.includes('export') || line.includes('return')) { confidence = 'high'; }
```

On a casing mismatch the exact-match branch is skipped, so the real target stays `medium`, while an unrelated line containing `return`/`export`/`function` is promoted to `high` and sorts above it — pointing `selectTargetFile` at the wrong line.

## Fix

```diff
-if (matchedTerm && line.includes(matchedTerm)) {
+if (matchedTerm && line.toLowerCase().includes(matchedTerm.toLowerCase())) {
   confidence = 'high';
```

## Verification

`searchTerms: ["Sign Up"]` against:

```jsx
<button>sign up</button>       // the real edit target
// return to sign up page       // unrelated comment
```

| Line | Before | After |
|---|---|---|
| `<button>sign up</button>` | `medium` | **`high`** |
| `// return to sign up page` | `high` (via `return`) | `high` |

The real target is now correctly ranked `high` instead of being downgraded below the comment.
