### PR TITLE
fix(cli): mask API key prompts

### DIFF
--- a/packages/create-open-lovable/lib/prompts.js
+++ b/packages/create-open-lovable/lib/prompts.js
@@ -55,9 +55,10 @@ export function getEnvPrompts(provider) {
 
   // Always include Firecrawl API key
   prompts.push({
-    type: 'input',
+    type: 'password',
     name: 'firecrawlApiKey',
     message: 'Firecrawl API key (for web scraping):',
+    mask: '*',
     validate: (input) => {
       if (!input || input.trim() === '') {
         return 'Firecrawl API key is required for web scraping functionality';
@@ -68,9 +69,10 @@ export function getEnvPrompts(provider) {
 
   if (provider === 'e2b') {
     prompts.push({
-      type: 'input',
+      type: 'password',
       name: 'e2bApiKey',
       message: 'E2B API key:',
+      mask: '*',
       validate: (input) => {
         if (!input || input.trim() === '') {
           return 'E2B API key is required';
@@ -124,9 +126,10 @@ export function getEnvPrompts(provider) {
     });
 
     prompts.push({
-      type: 'input',
+      type: 'password',
       name: 'vercelToken',
       message: 'Vercel Access Token:',
+      mask: '*',
       when: (answers) => answers.vercelAuthMethod === 'pat',
       validate: (input) => {
         if (!input || input.trim() === '') {
@@ -159,30 +162,34 @@ export function getEnvPrompts(provider) {
   });
 
   prompts.push({
-    type: 'input',
+    type: 'password',
     name: 'anthropicApiKey',
     message: 'Anthropic API key:',
+    mask: '*',
     when: (answers) => answers.aiProviders && answers.aiProviders.includes('anthropic')
   });
 
   prompts.push({
-    type: 'input',
+    type: 'password',
     name: 'openaiApiKey',
     message: 'OpenAI API key:',
+    mask: '*',
     when: (answers) => answers.aiProviders && answers.aiProviders.includes('openai')
   });
 
   prompts.push({
-    type: 'input',
+    type: 'password',
     name: 'geminiApiKey',
     message: 'Gemini API key:',
+    mask: '*',
     when: (answers) => answers.aiProviders && answers.aiProviders.includes('gemini')
   });
 
   prompts.push({
-    type: 'input',
+    type: 'password',
     name: 'groqApiKey',
     message: 'Groq API key:',
+    mask: '*',
     when: (answers) => answers.aiProviders && answers.aiProviders.includes('groq')
   });
 

--- a/packages/create-open-lovable/package.json
+++ b/packages/create-open-lovable/package.json
@@ -8,7 +8,7 @@
     "create-open-lovable": "./index.js"
   },
   "scripts": {
-    "test": "node index.js --dry-run"
+    "test": "node --test && node index.js --dry-run"
   },
   "keywords": [
     "lovable",

--- a/packages/create-open-lovable/test/prompts.test.js
+++ b/packages/create-open-lovable/test/prompts.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getEnvPrompts } from '../lib/prompts.js';
+
+const secretNames = new Set([
+  'firecrawlApiKey',
+  'e2bApiKey',
+  'vercelToken',
+  'anthropicApiKey',
+  'openaiApiKey',
+  'geminiApiKey',
+  'groqApiKey'
+]);
+
+test('API key prompts mask terminal input', () => {
+  const prompts = [...getEnvPrompts('e2b'), ...getEnvPrompts('vercel')];
+  const secretPrompts = prompts.filter((prompt) => secretNames.has(prompt.name));
+
+  assert.deepEqual(new Set(secretPrompts.map((prompt) => prompt.name)), secretNames);
+  for (const prompt of secretPrompts) {
+    assert.equal(prompt.type, 'password', prompt.name);
+    assert.equal(prompt.mask, '*', prompt.name);
+  }
+});


### PR DESCRIPTION
## Summary

- use masked password prompts for all API keys and access tokens collected by `create-open-lovable`
- add a Node built-in regression test covering every secret prompt
- keep non-secret team and project identifiers as normal text inputs

## Why

The CLI currently collects API keys with plain `input` prompts, which echoes secrets in the terminal. Switching only secret fields to Inquirer's `password` prompt reduces exposure in screen sharing, recordings, and shoulder surfing.

This is input-hardening only; it does not claim that Open Lovable transmits credentials.

## Tests

- `node --test`
- 1 passed